### PR TITLE
[pycharm] [py.test] Issue for locate test for django

### DIFF
--- a/python/helpers/pycharm/_jb_pytest_runner.py
+++ b/python/helpers/pycharm/_jb_pytest_runner.py
@@ -8,11 +8,17 @@ from _pytest.config import get_plugin_manager
 from _jb_runner_tools import jb_start_tests, jb_patch_separator, jb_doc_args
 from teamcity import pytest_plugin
 
+def set_up_django_environ():
+    import django
+    # TODO pass PYCHARM_DJANGO_SETTINGS_MODULE into py.test runner if enable django support
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", os.environ.get('PYCHARM_DJANGO_SETTINGS_MODULE', "settings"))
+    django.setup()
 
 
 if __name__ == '__main__':
     path, targets, additional_args = jb_start_tests()
     sys.argv += additional_args
+    set_up_django_environ()
     joined_targets = jb_patch_separator(targets, fs_glue="/", python_glue="::", fs_to_python_glue=".py::")
     # When file is launched in py.test it should be file.py: you can't provide it as bare module
     joined_targets = [t + ".py" if ":" not in t else t for t in joined_targets]


### PR DESCRIPTION
fixes issue for django and py.test in case select target class or method test.

We received that exception, because test files contains django specific code.
Before search test modules we need setup django enviroment when enabled django support

```
 Traceback (most recent call last):
  File "/home/apkawa/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/171.3780.115/helpers/pycharm/_jb_pytest_runner.py", line 25, in <module>
    joined_targets = jb_patch_separator(targets, fs_glue="/", python_glue="::", fs_to_python_glue=".py::")
  File "/home/apkawa/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/171.3780.115/helpers/pycharm/_jb_runner_tools.py", line 374, in jb_patch_separator
    return map(_patch_target, targets)
  File "/home/apkawa/.local/share/JetBrains/Toolbox/apps/PyCharm-P/ch-0/171.3780.115/helpers/pycharm/_jb_runner_tools.py", line 365, in _patch_target
    m = importlib.import_module(module_to_import)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/media/hd1000/work/new_trustedservice/src/site_apllications/utils/tests/test_stopword.py", line 6, in <module>
    from trustedservice.models import User
  File "/media/hd1000/work/new_trustedservice/src/site_apllications/trustedservice/models/__init__.py", line 4, in <module>
    from .main import *
  File "/media/hd1000/work/new_trustedservice/src/site_apllications/trustedservice/models/main.py", line 9, in <module>
    from easy_thumbnails.fields import ThumbnailerImageField
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/easy_thumbnails/fields.py", line 2, in <module>
    from easy_thumbnails import files
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/easy_thumbnails/files.py", line 14, in <module>
    from easy_thumbnails import engine, exceptions, models, utils, signals, storage
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/easy_thumbnails/models.py", line 55, in <module>
    class File(models.Model):
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/easy_thumbnails/models.py", line 56, in File
    storage_hash = models.CharField(max_length=40, db_index=True)
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 1043, in __init__
    super(CharField, self).__init__(*args, **kwargs)
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 166, in __init__
    self.db_tablespace = db_tablespace or settings.DEFAULT_INDEX_TABLESPACE
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/django/conf/__init__.py", line 53, in __getattr__
    self._setup(name)
  File "/home/apkawa/.envs/new_trustedservice/local/lib/python2.7/site-packages/django/conf/__init__.py", line 39, in _setup
    % (desc, ENVIRONMENT_VARIABLE))
django.core.exceptions.ImproperlyConfigured: Requested setting DEFAULT_INDEX_TABLESPACE, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```